### PR TITLE
Fix for issue #33

### DIFF
--- a/ColdWaters_Data/StreamingAssets/dotmod/campaign/maps/south_china_sea_world_objects.txt
+++ b/ColdWaters_Data/StreamingAssets/dotmod/campaign/maps/south_china_sea_world_objects.txt
@@ -1116,7 +1116,7 @@ ChildMeshPosition=33.254,0,-61.144
 ChildMeshRotation=0,282.080,0
 
 ChildObject=terrain/scenery/landhit
-ChildMeshPosition=36.868,0,-60.445
+ChildMeshPosition=36.868,0.5,-60.445
 ChildMeshRotation=0,282.080,0
 
 ChildObject=terrain/scenery/landhit


### PR DESCRIPTION
Move target 2 upward vertically 0.5...whatever units are used. 0.3 would also probably work, but having the weapon explode above the target is fairly realistic, so I'm good it with.