### PR TITLE
Fixing towed array position for Skipjack

### DIFF
--- a/ColdWaters_Data/StreamingAssets/dotmod/vessels/usn_68_ssn_skipjack.txt
+++ b/ColdWaters_Data/StreamingAssets/dotmod/vessels/usn_68_ssn_skipjack.txt
@@ -39,7 +39,7 @@ TowedArrayModel=FALSE
 AnechoicCoating=FALSE
 RADAR=usn_bps_12
 RADARSignature=SMALL
-TowedArrayPosition=0.0718,0,-0.55
+TowedArrayPosition=0.0737,0,-0.55
 
 [Weapon Systems]
 TorpedoTypes=usn_mk37,usn_mk16,usn_mk45

--- a/ColdWaters_Data/StreamingAssets/dotmod/vessels/usn_84_ssn_skipjack.txt
+++ b/ColdWaters_Data/StreamingAssets/dotmod/vessels/usn_84_ssn_skipjack.txt
@@ -39,7 +39,7 @@ TowedArrayModel=usn_bqr_25
 AnechoicCoating=FALSE
 RADAR=usn_bps_12
 RADARSignature=SMALL
-TowedArrayPosition=0.0718,0,-0.55
+TowedArrayPosition=0.0737,0,-0.55
 
 [Weapon Systems]
 TorpedoTypes=usn_mk48,usn_moss


### PR DESCRIPTION
The towed array position for the Skipjack is a bit of. This will fix it.